### PR TITLE
fix conflicting message

### DIFF
--- a/Resources/views/Dropzone/open.html.twig
+++ b/Resources/views/Dropzone/open.html.twig
@@ -17,7 +17,7 @@
                 {% endif %}
             </p>
         {% endif %}
-        {% if dropzone.isAllowDrop %}
+        {% if dropzone.isAllowDrop and drop is not null and not drop.finished %}
             <p class="text-muted">
                 {{ 'Deposit phase'|trans({}, 'icap_dropzone') }}
                 {% if not dropzone.manualPlanning %}


### PR DESCRIPTION
"en cours de dépôt"  was shown even if user drop was finished. In this case, both messages "en cours de dépôt" and "Fini ! Patience votre copie est [...]" were displayed.

I may be wrong but it seems quite contradictory
