### PR TITLE
Output css file to dedicated folder (outside bundle sources)

### DIFF
--- a/Resources/public/css/style.css
+++ b/Resources/public/css/style.css
@@ -1,1 +1,0 @@
-.container-dropzone{padding-bottom:15px}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -4,7 +4,7 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    {% stylesheets debug=false filter='lessphp'  output='bundles/icapdropzone/css/style.css'
+    {% stylesheets debug=false filter='lessphp'  output='css/icapdropzone/style.css'
       "@IcapDropzoneBundle/Resources/views/less/style.less"
     %}
         <link rel="stylesheet" href="{{ asset_url }}" screen="media" />


### PR DESCRIPTION
If the assets have been installed using the symlink option (which is the default), outputting css files into _web/bundles/somebundle_ means outputting them directly into the _Resource/public_ directory of the bundle, which can cause permission issues as the vendor directory isn't supposed to be writable.

This PR redirects the output to a dedicated _css_ folder to avoid that (similar changes are coming in the core bundle).

PS: I would be nice if you could create a tag (last one is pretty old anyway). 
